### PR TITLE
ParallelQueue & Event improvements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,9 +11,9 @@ jobs:
     if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@master
+      - uses: actions/setup-node@v3
         with:
           node-version: '18'
           cache: 'yarn'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zajno/common",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "description": "Zajno's re-usable utilities for JS/TS projects",
   "repository": {
     "type": "git",


### PR DESCRIPTION
 - `ParallelQueue`'s `finished` event now is `OneTimeLateEvent`, so you can subscribe to it no matter how late.
 - `Event` now creates internal logger via `withLogger` method; in future it will not create one by default.