### PR TITLE
Upgrades: Types and Time shifters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zajno/common",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Zajno's re-usable utilities for JS/TS projects",
   "repository": {
     "type": "git",

--- a/src/dates/__tests__/dates.test.ts
+++ b/src/dates/__tests__/dates.test.ts
@@ -1215,4 +1215,18 @@ describe('Date Helpers', () => {
         DateHelpers.ensureDates(undefined, 'start', 'end', 'date');
         expect(empty).toBeUndefined();
     });
+
+    test('setDayOfWeek', () => {
+        const baseDate = () => new Date('2023-11-09'); // day == 4
+        // const convert = (d: number, future: boolean | null = null) => DateHelpers.setDayOfWeek(baseDate(), d, future).getDay();
+
+        expect(DateHelpers.setDayOfWeek(baseDate(), 0)).toStrictEqual(new Date('2023-11-05'));
+        expect(DateHelpers.setDayOfWeek(baseDate(), 1)).toStrictEqual(new Date('2023-11-06'));
+        expect(DateHelpers.setDayOfWeek(baseDate(), 2)).toStrictEqual(new Date('2023-11-07'));
+        expect(DateHelpers.setDayOfWeek(baseDate(), 6)).toStrictEqual(new Date('2023-11-11'));
+        expect(DateHelpers.setDayOfWeek(baseDate(), 13)).toStrictEqual(new Date('2023-11-18'));
+        expect(DateHelpers.setDayOfWeek(baseDate(), 2, true)).toStrictEqual(new Date('2023-11-14'));
+        expect(DateHelpers.setDayOfWeek(baseDate(), 9, true)).toStrictEqual(new Date('2023-11-14'));
+        expect(DateHelpers.setDayOfWeek(baseDate(), -1, false)).toStrictEqual(new Date('2023-11-04'));
+    });
 });

--- a/src/dates/parse.ts
+++ b/src/dates/parse.ts
@@ -3,7 +3,7 @@ export function getTime(d: Date | number): number {
     return d instanceof Date ? d.getTime() : d;
 }
 
-export function getDate(d: Date | number | string): Date {
+export function getDate(d: Date | number | string | undefined): Date {
     if (!d) {
         return null;
     }

--- a/src/dates/shift.ts
+++ b/src/dates/shift.ts
@@ -88,3 +88,27 @@ export function isSame(d1: Date | number, d2: Date | number, g: Granularity, loc
     const s2 = startOf(d2, g, local);
     return s1.getTime() === s2.getTime();
 }
+
+/**
+ * Allows to set day of week, symmetric to Date.getDay()
+ * @param d Date representation
+ * @param dayOfWeek 0..6 Sunday..Saturday
+ * @param future true - only forward, false - only backward, null - closest
+ * @param local whether to use local time
+ * @returns Date with the same time as d, but with the updated day of week
+ */
+export function setDayOfWeek(d: Date | number, dayOfWeek: number, future: boolean | null = null, local = false) {
+    const res = getDate(d);
+    const currentDayOfWeek = local ? res.getDay() : res.getUTCDay();
+    let diff = dayOfWeek - currentDayOfWeek;
+
+    if (future != null) {
+        if (future && diff < 0) {
+            diff += 7;
+        }
+        if (!future && diff > 0) {
+            diff -= 7;
+        }
+    }
+    return add(res, diff, 'day', local);
+}

--- a/src/dates/tz.ts
+++ b/src/dates/tz.ts
@@ -46,4 +46,9 @@ export namespace Timezones {
         expect(Timezones.getOffset('Asia/Kolkata')).toBe(-270);
     */
 
+    export function shiftToTimeZone(date: Date, tz: string | number): Date {
+        const offset = typeof tz === 'number' ? tz : getOffset(tz);
+        const shifted = new Date(date.getTime() + offset * 60 * 1000);
+        return shifted;
+    }
 }

--- a/src/lazy/light.ts
+++ b/src/lazy/light.ts
@@ -1,11 +1,12 @@
 import type { IDisposable } from '../functions/disposer';
+import type { IResetableModel } from '../models/types';
 
-export type LazyLight<T> = IDisposable & {
+export type ILazy<T> = {
     readonly value: T;
     readonly hasValue: boolean;
-
-    reset(): void;
 };
+
+export type LazyLight<T> = ILazy<T> & IDisposable & IResetableModel;
 
 export function createLazy<T>(factory: () => T) {
     const _factory = factory;

--- a/src/lazy/promise.ts
+++ b/src/lazy/promise.ts
@@ -1,6 +1,12 @@
 import type { IDisposable } from '../functions/disposer';
+import type { ILazy, LazyLight } from './light';
 
-export class LazyPromise<T> implements IDisposable {
+export type ILazyPromise<T> = ILazy<T> & {
+    readonly busy: boolean;
+    readonly promise: Promise<T>;
+};
+
+export class LazyPromise<T> implements IDisposable, LazyLight<T>, ILazyPromise<T> {
 
     private _instance: T = undefined;
     private _busy: boolean = null;

--- a/src/lazy/singleton.ts
+++ b/src/lazy/singleton.ts
@@ -1,6 +1,7 @@
 import type { IDisposable } from '../functions/disposer';
+import type { LazyLight } from './light';
 
-export class Lazy<T> implements IDisposable {
+export class Lazy<T> implements IDisposable, LazyLight<T> {
 
     protected _instance: T = null;
 

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -16,6 +16,14 @@ export interface IResetableModel {
     readonly isDefault?: boolean;
 }
 
+export interface IFocusableModel {
+    focused: boolean;
+}
+
+export interface IErrorModel {
+    readonly error: string;
+}
+
 export interface ICountableModel {
     readonly count: number;
     readonly selectedCount?: number;

--- a/src/models/wrappers.ts
+++ b/src/models/wrappers.ts
@@ -61,7 +61,7 @@ export function spyModel<T, TModel extends (IValueModel<T> & object)>(model: TMo
     });
 }
 
-export function wrap<T, TModel extends IValueModel<T>, TRes>(model: TModel, getter: (m: TModel) => TRes, setter: (v: TRes, model: TModel) => void): IValueModel<TRes> {
+export function wrap<TSource, TRes>(model: TSource, getter: (m: TSource) => TRes, setter: (v: TRes, model: TSource) => void): IValueModel<TRes> {
     return {
         get value() { return getter(model); },
         set value(v: TRes) { setter(v, model); },

--- a/src/types/deep.ts
+++ b/src/types/deep.ts
@@ -24,7 +24,7 @@ export type DeepPartial<T> = T extends (AnyFunction | Primitive)
     : (T extends Array<infer U>
         ? Array<DeepPartial<U>>
         : {
-            [P in keyof T]?: DeepPartial<T[P]>;
+            [P in keyof T]?: DeepPartial<T[P]> | undefined;
         }
     );
 
@@ -43,5 +43,27 @@ export type DeepMutable<T> = T extends (AnyFunction | Primitive)
         ? Array<DeepMutable<U>>
         : {
             -readonly [P in keyof T]: DeepMutable<T[P]>;
+        }
+    );
+
+export type DeepPickNullable<T, K extends keyof T> = {
+    [P in K]?: null | undefined | DeepPartialNullable<T[P]>;
+};
+
+export type DeepNullable<T> = T extends (AnyFunction | Primitive)
+    ? T
+    : (T extends Array<infer U>
+        ? Array<DeepNullable<U>>
+        : {
+            [P in keyof T]: null | DeepNullable<T[P]>;
+        }
+    );
+
+export type DeepPartialNullable<T> = T extends (AnyFunction | Primitive)
+    ? T
+    : (T extends Array<infer U>
+        ? Array<DeepPartialNullable<U>>
+        : {
+            [P in keyof T]?: null | undefined | DeepPartialNullable<T[P]>;
         }
     );

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -47,3 +47,7 @@ export type ToPlainObject<T> = T extends (AnyFunction | Primitive)
         ? T
         : never
     );
+
+export type PickNullable<T, K extends keyof T> = {
+    [P in K]?: T[P] | null | undefined;
+};


### PR DESCRIPTION
- types: Added abstract types for Lazy of all kinds
- types: loosed `dates.getDate` input type
- types: added `IFocusableModel` and `IErrorModel` interfaces for better granularity
- types: models/wrap: loosed generic constraint, helps to wrap any object
- types: added `PickNullable`, `DeepPickNullable`, `DeepNullable`, `DeepPartialNullable` – should be useful for `strict`ers.
- dates/tz: added `shiftToTimeZone` helper
- dates/shift: added `setDayOfWeek` helper