### PR TITLE
[common-mobx] added ComputedValueModel for wrapping `@computed` decorator

### DIFF
--- a/packages/common-mobx/package.json
+++ b/packages/common-mobx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zajno/common-mobx",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Zajno's re-usable utilities for JS/TS projects using MobX",
   "private": false,
   "repository": {

--- a/packages/common-mobx/src/viewModels/ComputedValueModel.ts
+++ b/packages/common-mobx/src/viewModels/ComputedValueModel.ts
@@ -1,0 +1,14 @@
+import { IValueModelReadonly } from '@zajno/common/models/types';
+import { computed, makeObservable } from 'mobx';
+
+export class ComputedValueModel<T> implements IValueModelReadonly<T> {
+    constructor(private readonly _getter: () => T) {
+        makeObservable(this, {
+            value: computed,
+        });
+    }
+
+    public get value(): T {
+        return this._getter();
+    }
+}


### PR DESCRIPTION
(when it's not convenient to use it directly)