### PR TITLE
[common] Events improvements

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zajno/common",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "description": "Zajno's re-usable utilities for JS/TS projects",
   "private": false,
   "repository": {

--- a/packages/common/src/__tests__/event.test.ts
+++ b/packages/common/src/__tests__/event.test.ts
@@ -54,6 +54,24 @@ describe('Event', () => {
         expect(handler3).toHaveBeenCalledAfter(handler2);
     });
 
+    it('resets handlers', () => {
+        const e = new Event<number>();
+        const handler1 = vi.fn();
+        e.on(handler1);
+
+        e.trigger(1);
+
+        expect(handler1).toHaveBeenCalledTimes(1);
+        expect(handler1).toHaveBeenCalledWith(1);
+
+        handler1.mockReset();
+        e.resetHandlers();
+
+        e.trigger(2);
+
+        expect(handler1).not.toHaveBeenCalled();
+    });
+
     it('triggers async handlers', async () => {
         const e = new Event<number>();
         const handler1 = vi.fn();

--- a/packages/common/src/__tests__/event.test.ts
+++ b/packages/common/src/__tests__/event.test.ts
@@ -134,4 +134,22 @@ describe('OneTimeLateEvent', () => {
         expect(handler).toHaveBeenCalledTimes(1);
         expect(handler).toHaveBeenCalledWith(1);
     });
+
+    it('callable after reset', () => {
+        const e = new OneTimeLateEvent<number>();
+        e.trigger(1);
+        const handler = vi.fn();
+        e.on(handler);
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler).toHaveBeenCalledWith(1);
+
+        handler.mockReset();
+
+        e.reset();
+        e.trigger(2);
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler).toHaveBeenCalledWith(2);
+    });
 });

--- a/packages/common/src/observing/event.late.ts
+++ b/packages/common/src/observing/event.late.ts
@@ -18,7 +18,7 @@ export class OneTimeLateEvent<T = any> extends Event<T> {
     }
 
     triggerAsync(data?: T): Promise<Error[]> {
-        if (this._triggeredWith) {
+        if (this._triggered) {
             return Promise.resolve([] as Error[]);
         }
 
@@ -33,9 +33,15 @@ export class OneTimeLateEvent<T = any> extends Event<T> {
             catchPromise(
                 handler(this._triggeredWith),
             );
-            return () => { /* no-op */ };
+            // do not skip adding to handlers in case the event will be reset
         }
 
         return super.on(handler);
     }
+
+    /** Allows this event to be triggered again and existing subscribers to receive it */
+    reset = () => {
+        this._triggered = false;
+        this._triggeredWith = undefined;
+    };
 }

--- a/packages/common/src/observing/event.ts
+++ b/packages/common/src/observing/event.ts
@@ -36,6 +36,11 @@ export class Event<T = any> implements IEvent<T> {
         return this;
     }
 
+    /** Clears handlers list */
+    public resetHandlers = () => {
+        this._handlers = [];
+    };
+
     public on(handler: EventHandler<T>): Unsubscribe {
         this._handlers.push(handler);
         return () => {


### PR DESCRIPTION
 - introduced `OneTimeLateEvent.reset()` for subsequent triggers;
 - introduced `Event.resetHandlers()` for cleaning up handlers list;