### PR TITLE
[common] Lazy: Expires

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11657,7 +11657,7 @@
         },
         "packages/common": {
             "name": "@zajno/common",
-            "version": "2.3.16",
+            "version": "2.3.18",
             "license": "MIT",
             "devDependencies": {
                 "@faker-js/faker": "^8.4.1",
@@ -11717,7 +11717,7 @@
         },
         "packages/common-mobx": {
             "name": "@zajno/common-mobx",
-            "version": "1.3.7",
+            "version": "1.3.9",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^20.12.7",

--- a/packages/common-mobx/package.json
+++ b/packages/common-mobx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zajno/common-mobx",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Zajno's re-usable utilities for JS/TS projects using MobX",
   "private": false,
   "repository": {

--- a/packages/common-mobx/src/lazy/__tests__/lazy.test.ts
+++ b/packages/common-mobx/src/lazy/__tests__/lazy.test.ts
@@ -32,7 +32,7 @@ describe('LazyPromise', () => {
         const l = new LazyPromiseObservable(() => setTimeoutAsync(200).then(() => VAL));
 
         expect(l.hasValue).toBe(false);
-        expect(l.busy).toBe(false);
+        expect(l.busy).toBeNull();
 
         expect(l.value).toBeUndefined();
         expect(l.busy).toBe(true);

--- a/packages/common-mobx/src/structures/__tests__/promiseCache.test.ts
+++ b/packages/common-mobx/src/structures/__tests__/promiseCache.test.ts
@@ -84,7 +84,7 @@ describe('PromiseCache observable', () => {
     });
 
     it('handles invalidation by timeout', async () => {
-        const fetcher = vi.fn(async (id: string) => ({ id }));
+        const fetcher = vi.fn(async (id: string) => setTimeoutAsync(10).then(() => ({ id })));
 
         const cache = new PromiseCacheObservable(fetcher)
             .useInvalidationTime(10)
@@ -119,7 +119,7 @@ describe('PromiseCache observable', () => {
             // here busy should be true since fetch is in progress
             expect(deferred.busy).toBe(true);
 
-            await setTimeoutAsync(5);
+            await setTimeoutAsync(10);
 
             expect(deferred.current).toStrictEqual({ id: '1' });
             expect(deferred.busy).toBe(false);

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zajno/common",
-  "version": "2.3.17",
+  "version": "2.3.18",
   "description": "Zajno's re-usable utilities for JS/TS projects",
   "private": false,
   "repository": {

--- a/packages/common/src/api/call.ts
+++ b/packages/common/src/api/call.ts
@@ -119,6 +119,6 @@ export function buildApiCaller<TExtra extends object = Record<string, any>>(opti
         }
 
         const response = await request(config) as { data: TOut };
-        return PostProcessors.process(api, response.data);
+        return PostProcessors.process(api, response?.data);
     };
 }

--- a/packages/common/src/functions/__tests__/throttle.test.ts
+++ b/packages/common/src/functions/__tests__/throttle.test.ts
@@ -146,7 +146,7 @@ describe('throttle', () => {
         loadMany.mockClear();
         resultProcessor.mockClear();
 
-        await setTimeoutAsync(100); // wait for 2nd batch
+        await setTimeoutAsync(150); // wait for 2nd batch
 
         expect(loadMany).toHaveBeenCalledTimes(1);
         expect(resultProcessor).toHaveBeenCalledTimes(1);

--- a/packages/common/src/lazy/light.ts
+++ b/packages/common/src/lazy/light.ts
@@ -1,24 +1,17 @@
-import type { IDisposable } from '../functions/disposer';
-import type { IResetableModel } from '../models/types';
-
-export type ILazy<T> = {
-    readonly value: T;
-    readonly hasValue: boolean;
-};
-
-export type LazyLight<T> = ILazy<T> & IDisposable & IResetableModel;
+import type { ILazy } from './types';
 
 export function createLazy<T>(factory: () => T) {
     const _factory = factory;
     let _instance: T | undefined = undefined;
 
-    const res: LazyLight<T> = {
+    const res: ILazy<T> = {
         get value() {
             if (_instance === undefined) {
                 _instance = _factory();
             }
             return _instance;
         },
+        get currentValue() { return _instance; },
         get hasValue() { return _instance !== undefined; },
         reset: () => {
             _instance = undefined;

--- a/packages/common/src/lazy/singleton.ts
+++ b/packages/common/src/lazy/singleton.ts
@@ -1,26 +1,50 @@
-import type { IDisposable } from '../functions/disposer';
-import type { LazyLight } from './light';
+import type { IExpireTracker } from '../structures/expire';
+import type { ILazy } from './types';
 
-export class Lazy<T> implements IDisposable, LazyLight<T> {
+export class Lazy<T> implements ILazy<T> {
 
-    protected _instance: T | null = null;
+    protected _instance: T | undefined;
+    private _expireTracker: IExpireTracker | undefined;
+    private _disposer?: (prev: T) => void;
 
-    constructor(
-        protected readonly _factory: (() => T),
-        protected readonly _disposer?: (prev: T) => void,
-    ) {
+    constructor(protected readonly _factory: (() => T)) { }
 
-    }
-
-    get hasValue() { return this._instance !== null; }
+    get hasValue() { return this._instance !== undefined; }
 
     get value() {
         this.ensureInstance();
         return this._instance!;
     }
 
+    get currentValue() {
+        return this._instance;
+    }
+
     /** Override me: additional way to make sure instance is valid */
-    protected get isValid() { return this.hasValue; }
+    protected get isValid() {
+        if (!this.hasValue) {
+            return false;
+        }
+
+        if (this._expireTracker) {
+            if (this._expireTracker.isExpired) {
+                this.reset();
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public withDisposer = (disposer: (prev: T) => void) => {
+        this._disposer = disposer;
+        return this;
+    };
+
+    public withExpire = (tracker: IExpireTracker | undefined) => {
+        this._expireTracker = tracker;
+        return this;
+    };
 
     private ensureInstance() {
         if (this.isValid) {
@@ -38,15 +62,19 @@ export class Lazy<T> implements IDisposable, LazyLight<T> {
         return this;
     }
 
-    setInstance = (instance: T | null) => {
+    setInstance(instance: T | undefined) {
         this._instance = instance;
-    };
+
+        if (this._instance !== undefined && this._expireTracker) {
+            this._expireTracker.restart();
+        }
+    }
 
     reset() {
         if (this.hasValue && this._instance && this._disposer) {
             this._disposer(this._instance);
         }
-        this.setInstance(null);
+        this.setInstance(undefined);
     }
 
     dispose() { this.reset(); }

--- a/packages/common/src/lazy/singleton.ts
+++ b/packages/common/src/lazy/singleton.ts
@@ -3,7 +3,7 @@ import type { ILazy } from './types';
 
 export class Lazy<T> implements ILazy<T> {
 
-    protected _instance: T | undefined;
+    protected _instance: T | undefined = undefined;
     private _expireTracker: IExpireTracker | undefined;
     private _disposer?: (prev: T) => void;
 

--- a/packages/common/src/lazy/types.ts
+++ b/packages/common/src/lazy/types.ts
@@ -1,0 +1,14 @@
+import { IDisposable } from '../functions/disposer';
+import { IResetableModel } from '../models/types';
+
+export type ILazy<T> = IDisposable & IResetableModel & {
+    readonly value: T;
+    readonly hasValue: boolean;
+    /** should not call the factory or change the value either way */
+    readonly currentValue: T | undefined;
+};
+
+export type ILazyPromise<T> = ILazy<T> & {
+    readonly busy: boolean | null;
+    readonly promise: Promise<T>;
+};

--- a/packages/common/src/structures/__tests__/tempoCache.test.ts
+++ b/packages/common/src/structures/__tests__/tempoCache.test.ts
@@ -1,31 +1,78 @@
 import { TempoCache } from '../tempoCache';
 import { setTimeoutAsync } from '../../async/timeout';
+import { createLazy } from '../../lazy/light';
+import { LazyPromise } from '../../lazy/promise';
 
 describe('TempoCache', () => {
     it('just works', async () => {
-        let incrementer = 1;
+        let incrementor = 1;
 
-        const example = new TempoCache(() => Promise.resolve(incrementer++), 199);
-
-        expect(await example.current).toBe(1);
-        await expect(example.current).resolves.toBe(1);
-
-        await setTimeoutAsync(100);
+        const example = new TempoCache(() => Promise.resolve(incrementor++), 99);
 
         await expect(example.current).resolves.toBe(1);
 
-        await setTimeoutAsync(200);
+        await setTimeoutAsync(50);
+
+        // still the same value
+        await expect(example.current).resolves.toBe(1);
+
+        await setTimeoutAsync(50);
+
+        // value is expired, incremented
+        await expect(example.current).resolves.toBe(2);
+
+        await setTimeoutAsync(50);
 
         await expect(example.current).resolves.toBe(2);
 
-        await setTimeoutAsync(100);
-
-        await expect(example.current).resolves.toBe(2);
-        await expect(example.current).resolves.toBe(2);
-
-        await setTimeoutAsync(300);
+        await setTimeoutAsync(50);
 
         await expect(example.current).resolves.toBe(3);
-        await expect(example.current).resolves.toBe(3);
+    });
+
+    it('integration with lazy', async () => {
+        let incrementor = 0;
+
+        const lazy = createLazy(() => ++incrementor);
+
+        const example = TempoCache.createFromLazy(lazy, 10);
+
+        expect(lazy.hasValue).toBe(false);
+        expect(example.current).toBe(incrementor);
+        expect(example.isExpired).toBe(false);
+        expect(lazy.hasValue).toBe(true);
+
+        await setTimeoutAsync(15);
+
+        expect(example.isExpired).toBe(true);
+        expect(lazy.hasValue).toBe(true);
+
+        const prev = incrementor;
+        expect(lazy.value).toBe(prev);
+        expect(example.current).toBe(prev + 1);
+        expect(incrementor).toBe(prev + 1);
+    });
+
+    it('integration with lazy promise', async () => {
+        let incrementor = 0;
+
+        const lazy = new LazyPromise(() => Promise.resolve(++incrementor));
+
+        const example = TempoCache.createFromLazyPromise(lazy, 20);
+
+        expect(lazy.hasValue).toBe(false);
+        await expect(example.current).resolves.toBe(incrementor);
+        expect(example.isExpired).toBe(false);
+        expect(lazy.hasValue).toBe(true);
+
+        await setTimeoutAsync(20);
+
+        expect(example.isExpired).toBe(true);
+        expect(lazy.hasValue).toBe(true);
+
+        const prev = incrementor;
+        expect(lazy.value).toBe(prev);
+        await expect(example.current).resolves.toBe(prev + 1);
+        expect(incrementor).toBe(prev + 1);
     });
 });

--- a/packages/common/src/structures/expire.ts
+++ b/packages/common/src/structures/expire.ts
@@ -1,0 +1,25 @@
+
+export interface IExpireTracker {
+    readonly isExpired: boolean;
+    restart(): void;
+}
+
+export class ExpireTracker implements IExpireTracker {
+    private _expiringAt: number = 0; // already expired
+
+    constructor(public readonly lifetimeMs: number) { }
+
+    public get isExpired() { return Date.now() >= this._expiringAt; }
+
+    public restart() {
+        this._expiringAt = Date.now() + this.lifetimeMs;
+    }
+
+    public get remainingMs() {
+        return Math.max(0, this._expiringAt - Date.now());
+    }
+
+    public expire() {
+        this._expiringAt = 0;
+    }
+}

--- a/packages/common/src/structures/tempoCache.ts
+++ b/packages/common/src/structures/tempoCache.ts
@@ -1,18 +1,62 @@
+import type { ILazy, ILazyPromise } from '../lazy/types';
+import { IResetableModel } from '../models/types';
+import { ExpireTracker } from './expire';
 
+/**
+ * Calls factory fn to fetch and store some value for a limited time.
+ *
+ * To factory method be called, `current` getter must be accessed.
+*/
 export class TempoCache<T> {
 
-    private _expiringAt: number = 0; // already expired
     private _current: T | undefined = undefined;
 
-    constructor(readonly factory: () => T, readonly lifetimeMs: number) { }
+    public readonly tracker: ExpireTracker;
 
-    public get isExpired() { return Date.now() >= this._expiringAt; }
+    constructor(readonly factory: () => T, lifetimeMs: number) {
+        this.tracker = new ExpireTracker(lifetimeMs);
+    }
+
+    public get isExpired() { return this.tracker.isExpired; }
 
     public get current() {
         if (this.isExpired) {
             this._current = this.factory();
-            this._expiringAt = Date.now() + this.lifetimeMs;
+            this.tracker.restart();
         }
         return this._current;
+    }
+}
+
+/* istanbul ignore next -- @preserve */
+export namespace TempoCache {
+
+    function createFactory<T extends IResetableModel, P extends keyof T>(source: T, key: P) {
+        return () => {
+            // each time factory is called means value is invalidated
+            // so we need to reset the lazy
+            source.reset();
+            return source[key];
+        };
+    }
+
+    /**
+     * Creates a TempoCache instance which caches `ILazy.value` for a specified time.
+     *
+     * Note a limitation: calling `reset` (or changing the stored value directly in other way) on `lazy` will not affect the value cached by `TempoCache` instance.
+    */
+    export function createFromLazy<T>(lazy: ILazy<T>, lifetimeMs: number) {
+        const factory = createFactory(lazy, 'value');
+        return new TempoCache(factory, lifetimeMs);
+    }
+
+    /**
+     * Creates a TempoCache instance which caches `ILazyPromise.promise` for a specified time.
+     *
+     * Note a limitation: calling `reset` (or changing the stored value directly in other way) on `lazy` will not affect the value cached by `TempoCache` instance.
+    */
+    export function createFromLazyPromise<T>(lazy: ILazyPromise<T>, lifetimeMs: number) {
+        const factory = createFactory(lazy, 'promise');
+        return new TempoCache(factory, lifetimeMs);
     }
 }


### PR DESCRIPTION
 - Lazy & LazyPromise now accepts ExpireTracker instance for invalidating caching values;
 - a single validation thrower can be created via `createThrower`