### PR TITLE
[common] Loading: custom error class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11764,7 +11764,7 @@
         },
         "packages/common": {
             "name": "@zajno/common",
-            "version": "2.4.2",
+            "version": "2.4.3",
             "license": "MIT",
             "devDependencies": {
                 "@faker-js/faker": "^8.4.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zajno/common",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Zajno's re-usable utilities for JS/TS projects",
   "private": false,
   "repository": {

--- a/packages/common/src/math/object/math.composite.ts
+++ b/packages/common/src/math/object/math.composite.ts
@@ -76,15 +76,29 @@ export class CompositeObjectMath<T extends AnyObject> extends CompositeObjectOps
             return 0;
         }
 
-        if (typeof o2 === 'number' && o2 === 0 || typeof o2 !== 'number' && this.isEmpty(o2)) {
+        const checkRight = <K extends AnyObject>(val: number | K, getIsEmpty: (k: K) => boolean) => {
+            return typeof val === 'number' && val === 0 || typeof val !== 'number' && getIsEmpty(val);
+        };
+
+        if (checkRight(o2, v => this.isEmpty(v))) {
             return Number.POSITIVE_INFINITY;
         }
 
-        const vals = this._math.map(pair => {
-            const val = _getInnerValue(o1, pair.key);
-            return pair.ops.div(val, _getInnerValue(o2, pair.key));
+        const results = this._math.map(pair => {
+            const left = _getInnerValue(o1, pair.key);
+            if (pair.ops.isEmpty(left)) {
+                return 0;
+            }
+
+            const right = _getInnerValue(o2, pair.key);
+
+            if (checkRight(right, v => pair.ops.isEmpty(v))) {
+                return 0;
+            }
+
+            return pair.ops.div(left, right);
         }).filter(Boolean);
 
-        return Math.min(...vals);
+        return results.length ? Math.min(...results) : 0;
     }
 }

--- a/packages/common/src/models/LogicModel.ts
+++ b/packages/common/src/models/LogicModel.ts
@@ -1,4 +1,4 @@
-import { LoadingModel, withLoading } from './Loading';
+import { ExclusiveLoadingError, LoadingModel, withLoading } from './Loading';
 import { Getter, Nullable } from '../types';
 import { PromiseExtended } from '../structures/promiseExtended';
 import { createLogger, ILogger } from '../logger';
@@ -83,11 +83,11 @@ export class LogicModel {
                     let result: T | undefined;
                     if (!noLoading) {
                         const resultWithLoading = await withLoading(this._loading, worker, !!exclusive);
-                        if (resultWithLoading.exclusivenessFailed) {
+                        if (resultWithLoading.aborted) {
                             const othersNames = Array.from(this._runningActionNames, n => `"${n}"`).join(', ') || '<?>';
                             const message = `runAction(exclusive=${exclusive}): "${storedName}" has been skipped, others in progress: ${othersNames}`;
                             if (exclusive === 'throw') {
-                                throw new Error(message);
+                                throw new ExclusiveLoadingError(message, storedName);
                             }
 
                             this.logger.warn(message);

--- a/packages/common/src/models/LogicModel.ts
+++ b/packages/common/src/models/LogicModel.ts
@@ -3,7 +3,7 @@ import { Getter, Nullable } from '../types';
 import { PromiseExtended } from '../structures/promiseExtended';
 import { createLogger, ILogger } from '../logger';
 
-type RunOptions = {
+export type ActionRunOptions = {
     /** Action name, required for logging and joining. */
     name?: string;
 
@@ -27,7 +27,6 @@ type RunOptions = {
     noLogs?: boolean;
 };
 
-type ActionResult<T> = PromiseExtended<T | undefined, { exclusive: ExclusiveLoadingError }>;
 
 export class LogicModel {
 
@@ -49,7 +48,7 @@ export class LogicModel {
         return new LoadingModel(useFirstInit);
     }
 
-    protected runAction<T = unknown>(worker: () => Promise<T>, options: RunOptions = {}, errorCtx?: Getter<unknown>): ActionResult<T> {
+    protected runAction<T = unknown>(worker: () => Promise<T>, options: ActionRunOptions = {}, errorCtx?: Getter<unknown>): ActionResult<T> {
         const started = Date.now();
         const name = options.name;
         if (name && !options.noLogs) {
@@ -122,8 +121,7 @@ export class LogicModel {
             }
         };
 
-        return PromiseExtended.run(runner)
-            .expectError('exclusive', ExclusiveLoadingError)
+        return ActionResult.expectExclusive(PromiseExtended.run(runner))
             .onError(data => {
                 this.logger.error(...formatError({
                     name,
@@ -161,4 +159,23 @@ function formatError(this: void, { name, err, errorCtx, elapsed }: ErrorData) {
         ...prepend(getErrorCause(), '\nCause:'),
         ...prepend(Getter.toValue(errorCtx), '\nContext:'),
     ];
+}
+
+export type ActionResult<T, TCustomErrors extends Record<string, unknown> = Record<never, unknown>> = ReturnType<typeof ActionResult.expectExclusive<T | undefined, TCustomErrors>>;
+
+export namespace ActionResult {
+    export type Expect = { exclusive: ExclusiveLoadingError };
+
+    export namespace Expect {
+        export const Config = {
+            name: 'exclusive',
+            ErrCtor: ExclusiveLoadingError,
+        } as const;
+    }
+
+    export const expectExclusive = PromiseExtended.ErrorConfig.createExpecter(Expect.Config);
+
+    export function createSucceeded<T>(data: T): ActionResult<T> {
+        return expectExclusive(PromiseExtended.succeeded(data));
+    }
 }

--- a/packages/common/src/models/LogicModel.ts
+++ b/packages/common/src/models/LogicModel.ts
@@ -27,6 +27,8 @@ type RunOptions = {
     noLogs?: boolean;
 };
 
+type ActionResult<T> = PromiseExtended<T | undefined, { exclusive: ExclusiveLoadingError }>;
+
 export class LogicModel {
 
     protected readonly _loading: LoadingModel;
@@ -47,7 +49,7 @@ export class LogicModel {
         return new LoadingModel(useFirstInit);
     }
 
-    protected runAction<T = unknown>(worker: () => Promise<T>, options: RunOptions = {}, errorCtx?: Getter<unknown>): PromiseExtended<T | undefined> {
+    protected runAction<T = unknown>(worker: () => Promise<T>, options: RunOptions = {}, errorCtx?: Getter<unknown>): ActionResult<T> {
         const started = Date.now();
         const name = options.name;
         if (name && !options.noLogs) {
@@ -121,7 +123,7 @@ export class LogicModel {
         };
 
         return PromiseExtended.run(runner)
-            // .expectError('network', NetworkError)
+            .expectError('exclusive', ExclusiveLoadingError)
             .onError(data => {
                 this.logger.error(...formatError({
                     name,

--- a/packages/common/src/models/__tests__/loading.test.ts
+++ b/packages/common/src/models/__tests__/loading.test.ts
@@ -45,8 +45,8 @@ describe('LoadingModel', () => {
 
             expect(m.isLoading).toBeTruthy();
 
-            await expect(second).resolves.toStrictEqual({ exclusivenessFailed: true });
-            await expect(first).resolves.toStrictEqual({ exclusivenessFailed: false, result: 100 });
+            await expect(second).resolves.toStrictEqual({ aborted: true });
+            await expect(first).resolves.toStrictEqual({ aborted: false, result: 100 });
 
             expect(m.value).toBe(false);
             expect(m.isLoading).toBeFalsy();
@@ -60,7 +60,7 @@ describe('LoadingModel', () => {
             const first = m.useLoading(worker, true);
             expect(m.isLoading).toBeTruthy();
 
-            await expect(first).resolves.toStrictEqual({ exclusivenessFailed: false, result: 100 });
+            await expect(first).resolves.toStrictEqual({ aborted: false, result: 100 });
 
             expect(m.isLoading).toBeFalsy();
         });


### PR DESCRIPTION
 - optimized naming & type exports
 - extended `PromiseExtended.expectError`
 - minor improvement for `CompositeObjectMath` (`math/object.math.composite.ts`)