### PR TITLE
[common] Improved Extensibility

### DIFF
--- a/packages/common-firebase/package.json
+++ b/packages/common-firebase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zajno/common-firebase",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Zajno's re-usable Firebase utilities for JS/TS projects",
   "private": false,
   "type": "module",
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "@google-cloud/pubsub": "^4.10.0",
-    "@zajno/common": "^2.5",
+    "@zajno/common": "^2.6.2",
     "@zajno/common-mobx": "^1.5",
     "firebase": "^11.6",
     "firebase-admin": "^13.2.0",

--- a/packages/common-firebase/src/client/web/app.ts
+++ b/packages/common-firebase/src/client/web/app.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '@zajno/common/logger';
 import { FirebaseSettings, IFirebaseApp } from '../abstractions/app.js';
 import { initializeApp, FirebaseApp as FirebaseAppType, deleteApp } from 'firebase/app';
-import { Lazy } from '@zajno/common/lazy/singleton';
+import { Lazy } from '@zajno/common/lazy';
 import { assert } from '@zajno/common/functions/assert';
 
 let _instance: FirebaseAppType | null = null;

--- a/packages/common-mobx/package.json
+++ b/packages/common-mobx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zajno/common-mobx",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Zajno's re-usable utilities for JS/TS projects using MobX",
   "private": false,
   "type": "module",
@@ -40,7 +40,7 @@
     "mobx": "^6.13.7"
   },
   "peerDependencies": {
-    "@zajno/common": "^2.6.1",
+    "@zajno/common": "^2.6.2",
     "mobx": "^6.13",
     "tslib": "^2.8"
   },

--- a/packages/common-mobx/src/lazy/observable.ts
+++ b/packages/common-mobx/src/lazy/observable.ts
@@ -1,4 +1,4 @@
-import { Lazy } from '@zajno/common/lazy/singleton';
+import { Lazy } from '@zajno/common/lazy';
 import { LazyPromise } from '@zajno/common/lazy/promise';
 import { observable, makeObservable, action } from 'mobx';
 import { ObservableTypes } from '../observing/types.js';

--- a/packages/common-mobx/src/structures/promiseCache.ts
+++ b/packages/common-mobx/src/structures/promiseCache.ts
@@ -1,5 +1,7 @@
 import { observable, makeObservable, action } from 'mobx';
 import { PromiseCache } from '@zajno/common/structures/promiseCache';
+import { NumberModel } from '../viewModels/NumberModel.js';
+import { IMapModel, IValueModel } from '@zajno/common/models/types.js';
 
 export { DeferredGetter } from '@zajno/common/structures/promiseCache';
 
@@ -17,20 +19,14 @@ export class PromiseCacheObservable<T, K = string> extends PromiseCache<T, K> {
 
         makeObservable<
             PromiseCacheObservable<T, K>,
-            '_itemsCache'
-                | '_itemsStatus'
-                | '_busyCount'
-                | 'setStatus'
-                | 'setPromise'
-                | 'onBeforeFetch'
-                | 'storeResult'
-                | 'onFetchComplete'
-                | '_set'
-                | 'clear'
+            | 'setStatus'
+            | 'setPromise'
+            | 'onBeforeFetch'
+            | 'storeResult'
+            | 'onFetchComplete'
+            | '_set'
+            | 'clear'
         >(this, {
-            _busyCount: observable,
-            _itemsCache: observable.shallow,
-            _itemsStatus: observable,
             setStatus: action,
             setPromise: action,
             onBeforeFetch: action,
@@ -46,6 +42,18 @@ export class PromiseCacheObservable<T, K = string> extends PromiseCache<T, K> {
     useObserveItems(observeItems: boolean) {
         this._observeItems = observeItems;
         return this;
+    }
+
+    protected pure_createBusyCount(): IValueModel<number> {
+        return new NumberModel();
+    }
+
+    protected pure_createItemsCache(): IMapModel<string, T | null | undefined> {
+        return observable.map<string, T | null | undefined>(undefined, { deep: false });
+    }
+
+    protected pure_createItemsStatus(): IMapModel<string, boolean> {
+        return observable.map<string, boolean>();
     }
 
 

--- a/packages/common-mobx/src/viewModels/InitializableModel.ts
+++ b/packages/common-mobx/src/viewModels/InitializableModel.ts
@@ -1,4 +1,4 @@
-import NumberModel from './NumberModel.js';
+import { NumberModel } from './NumberModel.js';
 
 export class InitializableModel {
     private readonly _counter = new NumberModel(0);

--- a/packages/common-mobx/src/viewModels/NumberModel.ts
+++ b/packages/common-mobx/src/viewModels/NumberModel.ts
@@ -45,5 +45,3 @@ export class NumberModel implements INumberModel, IValueModel<number> {
     // @action
     decrement = (d = 1) => this.setValue(this._value - d);
 }
-
-export default NumberModel;

--- a/packages/common-mobx/src/viewModels/SelectModel.ts
+++ b/packages/common-mobx/src/viewModels/SelectModel.ts
@@ -6,7 +6,7 @@ import type { IValueModel, IResetableModel } from '@zajno/common/models/types';
 import { withLabel } from '@zajno/common/models/wrappers';
 import { Getter } from '@zajno/common/types/getter';
 import { Disposer, IDisposable } from '@zajno/common/functions/disposer';
-import NumberModel from './NumberModel.js';
+import { NumberModel } from './NumberModel.js';
 
 export class Select<T = any> extends ValidatableModel<T> implements IValueModel<string | null>, IResetableModel, IDisposable {
     private _index: IValueModel<number> = new NumberModel();
@@ -54,7 +54,7 @@ export class Select<T = any> extends ValidatableModel<T> implements IValueModel<
 
     // @computed
     get items(): readonly T[] {
-        return Getter.getValue(this._items);
+        return Getter.toValue(this._items);
     }
 
     get value(): string | null { return this.selectedValue; }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -56,6 +56,7 @@
     "./dates": "./src/dates/index.ts",
     "./fields": "./src/fields/index.ts",
     "./functions": "./src/functions/index.ts",
+    "./lazy": "./src/lazy/index.ts",
     "./localization": "./src/localization/index.ts",
     "./logger": "./src/logger/index.ts",
     "./math": "./src/math/index.ts",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zajno/common",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Zajno's re-usable utilities for JS/TS projects",
   "private": false,
   "type": "module",

--- a/packages/common/src/lazy/__tests__/lazy.test.ts
+++ b/packages/common/src/lazy/__tests__/lazy.test.ts
@@ -1,4 +1,4 @@
-import { Lazy } from '../singleton.js';
+import { Lazy } from '../lazy.js';
 import { LazyPromise } from '../promise.js';
 import { setTimeoutAsync } from '../../async/timeout.js';
 import { ExpireTracker } from '../../structures/expire.js';

--- a/packages/common/src/lazy/index.ts
+++ b/packages/common/src/lazy/index.ts
@@ -1,0 +1,4 @@
+export * from './types.js';
+export * from './light.js';
+export * from './lazy.js';
+export * from './promise.js';

--- a/packages/common/src/lazy/lazy.ts
+++ b/packages/common/src/lazy/lazy.ts
@@ -36,15 +36,15 @@ export class Lazy<T> implements ILazy<T> {
         return true;
     }
 
-    public withDisposer = (disposer: (prev: T) => void) => {
+    public withDisposer(disposer: (prev: T) => void) {
         this._disposer = disposer;
         return this;
-    };
+    }
 
-    public withExpire = (tracker: IExpireTracker | undefined) => {
+    public withExpire(tracker: IExpireTracker | undefined) {
         this._expireTracker = tracker;
         return this;
-    };
+    }
 
     private ensureInstance() {
         if (this.isValid) {

--- a/packages/common/src/lazy/promise.ts
+++ b/packages/common/src/lazy/promise.ts
@@ -34,10 +34,10 @@ export class LazyPromise<T> implements ILazyPromise<T> {
         return this._instance;
     }
 
-    public withExpire = (tracker: IExpireTracker | undefined) => {
+    public withExpire(tracker: IExpireTracker | undefined) {
         this._expireTracker = tracker;
         return this;
-    };
+    }
 
     protected ensureInstanceLoading() {
         if (this.busy === false && this._instance !== undefined && this._expireTracker?.isExpired) {
@@ -60,7 +60,7 @@ export class LazyPromise<T> implements ILazyPromise<T> {
         return res;
     }
 
-    public setInstance = (res: T | undefined) => {
+    public setInstance(res: T | undefined) {
         this._busy = false;
 
         // refresh promise so it won't keep old callbacks
@@ -75,13 +75,15 @@ export class LazyPromise<T> implements ILazyPromise<T> {
         }
 
         return res;
-    };
+    }
 
-    reset = () => {
+    reset() {
         this._busy = null;
         this._instance = this.initial;
         this._promise = undefined;
-    };
+    }
 
-    dispose = () => this.reset();
+    dispose() {
+        this.reset();
+    }
 }

--- a/packages/common/src/lazy/types.ts
+++ b/packages/common/src/lazy/types.ts
@@ -1,5 +1,5 @@
-import { IDisposable } from '../functions/disposer.js';
-import { IResetableModel } from '../models/types.js';
+import type { IDisposable } from '../functions/disposer.js';
+import type { IResetableModel } from '../models/types.js';
 
 export type ILazy<T> = IDisposable & IResetableModel & {
     readonly value: T;

--- a/packages/common/src/models/Loading.ts
+++ b/packages/common/src/models/Loading.ts
@@ -56,10 +56,10 @@ export class LoadingModel implements IValueModel<boolean>, IResetableModel {
         return withLoading(this, cb, exclusive);
     }
 
-    public reset = () => {
+    public reset() {
         this._firstInit = false;
         this._number.reset();
-    };
+    }
 
     public setValue(isLoading: boolean) {
         if (isLoading) {

--- a/packages/common/src/models/types.ts
+++ b/packages/common/src/models/types.ts
@@ -29,3 +29,18 @@ export interface ICountableModel {
     readonly selectedCount?: number;
     readonly isEmpty: boolean;
 }
+
+/** Lighter version of ES2015 Map with no constructor/symbols stuff. */
+export type IMapModel<K, V> = Pick<
+    Map<K, V>,
+    | 'clear'
+    | 'delete'
+    | 'get'
+    | 'has'
+    | 'set'
+    | 'size'
+    | 'entries'
+    | 'keys'
+    | 'values'
+    | 'forEach'
+>;

--- a/packages/common/src/structures/__tests__/promiseCache.test.ts
+++ b/packages/common/src/structures/__tests__/promiseCache.test.ts
@@ -71,6 +71,7 @@ describe('PromiseCache', () => {
         expect(loaderFn).toHaveBeenCalledTimes(1);
 
         expect(cache.keys()).toStrictEqual(['123']);
+        expect(Array.from(cache.keys(true))).toStrictEqual(['123']);
         cache.invalidate(123);
         expect(cache.keys()).toStrictEqual([]);
 
@@ -111,6 +112,7 @@ describe('PromiseCache', () => {
 
         expect(cache.keys()).toStrictEqual(filler.map((_, i) => i.toString()));
         expect(cache.keysParsed()).toStrictEqual(filler.map((_, i) => i));
+        expect(Array.from(cache.keysParsed(true)!)).toStrictEqual(filler.map((_, i) => i));
 
         cache.invalidate(1);
 

--- a/packages/scripts/publish/local.sh
+++ b/packages/scripts/publish/local.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-npm run build:full && npm run bundle && cd dist && yalc push --replace --update
+npm run build:full && npm run bundle && cd dist && yalc push --replace --update --sig


### PR DESCRIPTION
 - `Lazy`/`LazyPromise` now without arrow function methods;
 - `PromiseCache` now extensible with map-like data structures;
 - introduces breaking changes in how `Lazy` and `NumberModel` are exported. 